### PR TITLE
CLN : 시리얼 통신 포트 관련 변수 SERIAL_PORT 추가

### DIFF
--- a/raspi/main.py
+++ b/raspi/main.py
@@ -42,6 +42,8 @@ PIN_RLED		= 31
 SERVO_MIN_DUTY	= 3
 SERVO_MAX_DUTY	= 12
 
+SERIAL_PORT     = '/dev/ttyUSB0'
+
 
 ##======================= GPIO INIT =======================##
 
@@ -62,7 +64,7 @@ servo1 = gp.PWM(PIN_SERVO1, 50)
 servo0.start(0)
 servo1.start(0)
 
-ser = serial.Serial('/dev/ttyUSB0', 9600)
+ser = serial.Serial(SERIAL_PORT, 9600)
 
 
 ##==================== PUBLIC VARIABLES ====================##


### PR DESCRIPTION
이 변수를 조정하여 시리얼 통신에 사용되는 포트를 설정할 수 있다.

Resolves #80